### PR TITLE
Reorganize build scripts into scripts directory with platform separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ These scripts will:
 1. Set up the backend environment:
    ```bash
    # Linux/Mac
-   build/linux/backend/setup-env.sh
+   scripts/linux/backend/setup-env.sh
    
    # Windows
-   build\windows\backend\setup-env.bat
+   scripts\windows\backend\setup-env.bat
    ```
 
 2. Edit the generated `backend/.env` file with your actual credentials
@@ -101,10 +101,10 @@ These scripts will:
 1. Set up the frontend environment:
    ```bash
    # Linux/Mac
-   build/linux/frontend/setup-env.sh
+   scripts/linux/frontend/setup-env.sh
    
    # Windows
-   build\windows\frontend\setup-env.bat
+   scripts\windows\frontend\setup-env.bat
    ```
 
 2. Install dependencies and start the frontend:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,180 @@
+# MoneyPlant Scripts System
+
+This directory contains the scripts and configuration files for the MoneyPlant application, organized by platform and component.
+
+## Directory Structure
+
+```
+build/
+├── README.md                    # This file
+├── start-application.bat        # Windows main application startup
+├── start-application.sh         # Linux/Mac main application startup
+├── windows/                     # Windows-specific scripts
+│   ├── WINDOWS_SETUP.md        # Windows setup documentation
+│   ├── start-backend.bat       # Windows backend startup
+│   ├── start-frontend.bat      # Windows frontend startup
+│   ├── backend/
+│   │   └── setup-env.bat       # Windows backend environment setup
+│   └── frontend/
+│       └── setup-env.bat       # Windows frontend environment setup
+└── linux/                       # Linux/Mac-specific scripts
+    ├── start-backend.sh         # Linux/Mac backend startup
+    ├── start-frontend.sh        # Linux/Mac frontend startup
+    ├── backend/
+    │   └── setup-env.sh        # Linux/Mac backend environment setup
+    └── frontend/
+        └── setup-env.sh        # Linux/Mac frontend environment setup
+```
+
+## Usage
+
+### Root Level Scripts (Recommended)
+
+The root directory contains platform-agnostic scripts that automatically detect your OS and call the appropriate platform-specific scripts:
+
+#### Windows
+```cmd
+start-application.bat    # Complete application setup and startup
+start-backend.bat       # Backend only
+start-frontend.bat      # Frontend only
+```
+
+#### Linux/Mac
+```bash
+./start-application.sh  # Complete application setup and startup
+./start-backend.sh      # Backend only
+./start-frontend.sh     # Frontend only
+```
+
+### Direct Platform Scripts
+
+You can also call the platform-specific scripts directly:
+
+#### Windows
+```cmd
+build\start-application.bat
+build\windows\start-backend.bat
+build\windows\start-frontend.bat
+```
+
+#### Linux/Mac
+```bash
+build/start-application.sh
+build/linux/start-backend.sh
+build/linux/start-frontend.sh
+```
+
+## Environment Setup
+
+### Backend Environment
+
+The backend environment setup creates a `.env` file in the `backend/` directory with all necessary configuration:
+
+- Database connection settings
+- OAuth2 configuration (Google, Microsoft)
+- JWT configuration
+- CORS settings
+- Trino configuration
+- Application settings
+
+### Frontend Environment
+
+The frontend environment setup generates TypeScript environment files:
+
+- `src/environments/environment.ts` (development)
+- `src/environments/environment.prod.ts` (production)
+
+These files are automatically generated based on the backend `.env` file.
+
+## Platform Detection
+
+The root-level scripts automatically detect your operating system:
+
+- **Windows**: Detects `%OS%` environment variable
+- **Linux/Mac**: Detects `$OSTYPE` environment variable
+
+## Script Features
+
+### Windows Scripts
+- Use `mvnw.cmd` (Maven wrapper) instead of requiring global Maven installation
+- Comprehensive error handling and user guidance
+- Environment variable loading from `.env` files
+- Prerequisites checking (Java, Node.js, npm)
+
+### Linux/Mac Scripts
+- Use `mvnw` (Maven wrapper) for consistent Maven version
+- Shell-compatible environment variable handling
+- Prerequisites checking (Java, Node.js, npm)
+- Executable permissions automatically set
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission Denied (Linux/Mac)**
+   ```bash
+   chmod +x build/linux/*.sh build/linux/*/*.sh
+   ```
+
+2. **Maven Not Found**
+   - The scripts use Maven wrapper (`mvnw`/`mvnw.cmd`)
+   - No global Maven installation required
+   - Wrapper automatically downloads correct Maven version
+
+3. **Environment Variables Not Loading**
+   - Ensure `.env` file exists in `backend/` directory
+   - Run setup scripts to create environment files
+   - Check file permissions and syntax
+
+### Platform-Specific Issues
+
+#### Windows
+- See `build/windows/WINDOWS_SETUP.md` for detailed Windows setup guide
+- Ensure Java and Node.js are in PATH
+- Use Command Prompt or PowerShell (not Git Bash for batch files)
+
+#### Linux/Mac
+- Ensure shell scripts have execute permissions
+- Use bash or compatible shell
+- Check that Java and Node.js are properly installed
+
+## Development Workflow
+
+1. **Initial Setup**
+   ```bash
+   # Linux/Mac
+   ./start-application.sh
+   
+   # Windows
+   start-application.bat
+   ```
+
+2. **Daily Development**
+   ```bash
+   # Start backend
+   ./start-backend.sh    # or start-backend.bat
+   
+   # Start frontend (in new terminal)
+   cd frontend && npm start
+   ```
+
+3. **Environment Changes**
+   - Edit `backend/.env` for backend configuration
+   - Run setup scripts to regenerate frontend environment files
+
+## Security Notes
+
+- `.env` files contain sensitive information and are in `.gitignore`
+- Never commit `.env` files to version control
+- Use different credentials for development, staging, and production
+- Client IDs are safe for frontend code, but client secrets should never be included
+
+## Contributing
+
+When adding new build scripts:
+
+1. Create both Windows (`.bat`) and Linux/Mac (`.sh`) versions
+2. Place them in the appropriate platform directory
+3. Update this README with usage instructions
+4. Ensure scripts are executable (Linux/Mac)
+5. Test on both platforms if possible 

--- a/scripts/linux/backend/setup-env.sh
+++ b/scripts/linux/backend/setup-env.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# MoneyPlant Frontend Environment Setup Script
+# This script generates frontend environment files from environment variables
+
+echo "🔐 MoneyPlant Frontend Environment Setup"
+echo "=========================================="
+echo ""
+
+# Check if we're in the frontend directory
+if [ ! -f "angular.json" ]; then
+    echo "❌ This script must be run from the frontend directory"
+    exit 1
+fi
+
+# Check if .env file exists in the backend directory
+if [ -f "../backend/.env" ]; then
+    echo "📋 Loading environment variables from backend .env file..."
+    set -a  # automatically export all variables
+    source ../backend/.env
+    set +a  # stop automatically exporting
+else
+    echo "⚠️  Backend .env file not found. Using default values..."
+    # Set default values
+    GOOGLE_CLIENT_ID="your-google-client-id"
+    MICROSOFT_CLIENT_ID="your-microsoft-client-id"
+fi
+
+echo "📝 Generating frontend environment files..."
+echo ""
+
+# Generate development environment
+cat > src/environments/environment.ts << EOF
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:8080',
+  useMockData: true,
+  
+  // OAuth Configuration
+  oauth: {
+    google: {
+      clientId: '${GOOGLE_CLIENT_ID:-your-google-client-id}', // Replace with your Google Client ID
+      redirectUri: 'http://localhost:4200'
+    },
+    microsoft: {
+      clientId: '${MICROSOFT_CLIENT_ID:-your-microsoft-client-id}', // Replace with your Microsoft Azure AD Client ID
+      redirectUri: 'http://localhost:4200'
+    }
+  }
+};
+EOF
+
+# Generate production environment
+cat > src/environments/environment.prod.ts << EOF
+export const environment = {
+  production: true,
+  apiUrl: '/api', // In production, the API is typically served from the same domain
+  useMockData: false,
+  
+  // OAuth Configuration
+  oauth: {
+    google: {
+      clientId: '${GOOGLE_CLIENT_ID:-your-google-client-id}', // Replace with your Google Client ID
+      redirectUri: window.location.origin
+    },
+    microsoft: {
+      clientId: '${MICROSOFT_CLIENT_ID:-your-microsoft-client-id}', // Replace with your Microsoft Azure AD Client ID
+      redirectUri: window.location.origin
+    }
+  }
+};
+EOF
+
+echo "✅ Frontend environment files generated successfully!"
+echo ""
+echo "📋 Generated files:"
+echo "- src/environments/environment.ts (development)"
+echo "- src/environments/environment.prod.ts (production)"
+echo ""
+echo "🔒 Security reminder: Client IDs are not sensitive secrets and can be safely included in frontend code."
+echo "However, client secrets should never be included in frontend code." 

--- a/scripts/linux/frontend/setup-env.sh
+++ b/scripts/linux/frontend/setup-env.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# MoneyPlant Frontend Environment Setup Script
+# This script generates frontend environment files from environment variables
+
+echo "🔐 MoneyPlant Frontend Environment Setup"
+echo "=========================================="
+echo ""
+
+# Check if we're in the frontend directory
+if [ ! -f "angular.json" ]; then
+    echo "❌ This script must be run from the frontend directory"
+    exit 1
+fi
+
+# Check if .env file exists in the backend directory
+if [ -f "../../backend/.env" ]; then
+    echo "📋 Loading environment variables from backend .env file..."
+    set -a  # automatically export all variables
+    source ../../backend/.env
+    set +a  # stop automatically exporting
+else
+    echo "⚠️  Backend .env file not found. Using default values..."
+    # Set default values
+    GOOGLE_CLIENT_ID="your-google-client-id"
+    MICROSOFT_CLIENT_ID="your-microsoft-client-id"
+fi
+
+echo "📝 Generating frontend environment files..."
+echo ""
+
+# Generate development environment
+cat > src/environments/environment.ts << EOF
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:8080',
+  useMockData: true,
+  
+  // OAuth Configuration
+  oauth: {
+    google: {
+      clientId: '${GOOGLE_CLIENT_ID:-your-google-client-id}', // Replace with your Google Client ID
+      redirectUri: 'http://localhost:4200'
+    },
+    microsoft: {
+      clientId: '${MICROSOFT_CLIENT_ID:-your-microsoft-client-id}', // Replace with your Microsoft Azure AD Client ID
+      redirectUri: 'http://localhost:4200'
+    }
+  }
+};
+EOF
+
+# Generate production environment
+cat > src/environments/environment.prod.ts << EOF
+export const environment = {
+  production: true,
+  apiUrl: '/api', // In production, the API is typically served from the same domain
+  useMockData: false,
+  
+  // OAuth Configuration
+  oauth: {
+    google: {
+      clientId: '${GOOGLE_CLIENT_ID:-your-google-client-id}', // Replace with your Google Client ID
+      redirectUri: window.location.origin
+    },
+    microsoft: {
+      clientId: '${MICROSOFT_CLIENT_ID:-your-microsoft-client-id}', // Replace with your Microsoft Azure AD Client ID
+      redirectUri: window.location.origin
+    }
+  }
+};
+EOF
+
+echo "✅ Frontend environment files generated successfully!"
+echo ""
+echo "📋 Generated files:"
+echo "- src/environments/environment.ts (development)"
+echo "- src/environments/environment.prod.ts (production)"
+echo ""
+echo "🔒 Security reminder: Client IDs are not sensitive secrets and can be safely included in frontend code."
+echo "However, client secrets should never be included in frontend code." 

--- a/scripts/linux/start-backend.sh
+++ b/scripts/linux/start-backend.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+echo "🚀 Starting MoneyPlant Backend in Development Mode..."
+echo "Backend will be available at: http://localhost:8080"
+echo "API Documentation: http://localhost:8080/swagger-ui.html"
+echo "Health Check: http://localhost:8080/actuator/health"
+echo ""
+
+cd ../../backend
+
+# Check if .env file exists
+if [ -f ".env" ]; then
+    echo "📋 Loading environment variables from .env file..."
+    # Load environment variables from .env file
+    set -a  # automatically export all variables
+    source .env
+    set +a  # stop automatically exporting
+else
+    echo "⚠️  .env file not found. Creating one with default values..."
+    ../scripts/linux/backend/setup-env.sh
+    echo "📋 Loading environment variables from newly created .env file..."
+    set -a  # automatically export all variables
+    source .env
+    set +a  # stop automatically exporting
+fi
+
+echo "✅ Environment variables loaded from .env file"
+echo ""
+
+# Verify critical environment variables
+echo "🔍 Verifying environment variables:"
+echo "DB_HOST: $DB_HOST"
+echo "DB_PASSWORD: [HIDDEN]"
+echo "MICROSOFT_CLIENT_ID: $MICROSOFT_CLIENT_ID"
+echo "JWT_SECRET: [HIDDEN]"
+echo ""
+
+echo "🏃 Starting Spring Boot application..."
+echo ""
+
+mvn spring-boot:run -Dspring-boot.run.profiles=dev 

--- a/scripts/linux/start-frontend.sh
+++ b/scripts/linux/start-frontend.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Starting MoneyPlant Frontend in Development Mode..."
+echo "Frontend will be available at: http://localhost:4200"
+echo "Make sure the backend is running on port 8080"
+echo ""
+
+cd frontend
+npm install
+npm run start:dev 

--- a/scripts/start-application.bat
+++ b/scripts/start-application.bat
@@ -1,0 +1,81 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo 🚀 MoneyPlant Application Startup
+echo =================================
+echo.
+
+REM Function to check if a command exists
+:command_exists
+where %1 >nul 2>&1
+if %errorlevel% equ 0 (
+    exit /b 0
+) else (
+    exit /b 1
+)
+
+REM Check prerequisites
+echo 🔍 Checking prerequisites...
+
+where java >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ❌ Java is not installed. Please install Java 17 or later.
+    pause
+    exit /b 1
+)
+
+where node >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ❌ Node.js is not installed. Please install Node.js 18 or later.
+    pause
+    exit /b 1
+)
+
+where npm >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ❌ npm is not installed. Please install npm.
+    pause
+    exit /b 1
+)
+
+echo ✅ Prerequisites check passed
+echo.
+
+REM Setup backend environment
+echo 🔧 Setting up backend environment...
+cd backend
+
+if exist ".env" (
+    echo 📋 Backend .env file found
+) else (
+    echo 📝 Creating backend .env file...
+    call ..\scripts\windows\backend\setup-env.bat
+)
+
+cd ..
+
+REM Setup frontend environment
+echo 🔧 Setting up frontend environment...
+cd frontend
+
+echo 📝 Generating frontend environment files...
+call ..\scripts\windows\frontend\setup-env.bat
+
+cd ..
+
+echo.
+echo ✅ Environment setup completed!
+echo.
+echo 📋 Next steps:
+echo 1. Edit backend\.env file with your actual credentials
+echo 2. Run 'npm install' in the frontend directory if not done already
+echo 3. Start the backend: scripts\windows\start-backend.bat
+echo 4. Start the frontend: cd frontend ^&^& npm start
+echo.
+echo 📖 For detailed setup instructions, see scripts\windows\WINDOWS_SETUP.md
+echo.
+echo 🔒 Security reminder:
+echo - The .env file contains sensitive information and is in .gitignore
+echo - Never commit the .env file to version control
+echo - Use different credentials for development, staging, and production
+pause 

--- a/scripts/start-application.sh
+++ b/scripts/start-application.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+echo "🚀 MoneyPlant Application Startup"
+echo "================================="
+echo ""
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check prerequisites
+echo "🔍 Checking prerequisites..."
+
+if ! command_exists java; then
+    echo "❌ Java is not installed. Please install Java 17 or later."
+    exit 1
+fi
+
+if ! command_exists node; then
+    echo "❌ Node.js is not installed. Please install Node.js 18 or later."
+    exit 1
+fi
+
+if ! command_exists npm; then
+    echo "❌ npm is not installed. Please install npm."
+    exit 1
+fi
+
+echo "✅ Prerequisites check passed"
+echo ""
+
+# Setup backend environment
+echo "🔧 Setting up backend environment..."
+cd backend
+
+if [ -f ".env" ]; then
+    echo "📋 Backend .env file found"
+else
+    echo "📝 Creating backend .env file..."
+    ../scripts/linux/backend/setup-env.sh
+fi
+
+cd ..
+
+# Setup frontend environment
+echo "🔧 Setting up frontend environment..."
+cd frontend
+
+echo "📝 Generating frontend environment files..."
+../scripts/linux/frontend/setup-env.sh
+
+cd ..
+
+echo ""
+echo "✅ Environment setup completed!"
+echo ""
+echo "📋 Next steps:"
+echo "1. Edit backend/.env file with your actual credentials"
+echo "2. Run 'npm install' in the frontend directory if not done already"
+echo "3. Start the backend: scripts/linux/start-backend.sh"
+echo "4. Start the frontend: cd frontend && npm start"
+echo ""
+echo "🔒 Security reminder:"
+echo "- The .env file contains sensitive information and is in .gitignore"
+echo "- Never commit the .env file to version control"
+echo "- Use different credentials for development, staging, and production" 

--- a/scripts/windows/WINDOWS_SETUP.md
+++ b/scripts/windows/WINDOWS_SETUP.md
@@ -1,0 +1,179 @@
+# MoneyPlant Windows Setup Guide
+
+This guide will help you set up and run the MoneyPlant application on Windows.
+
+## Prerequisites
+
+Before running the application, ensure you have the following installed:
+
+### 1. Java Development Kit (JDK)
+- **Version**: Java 17 or later
+- **Download**: [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) or [OpenJDK](https://adoptium.net/)
+- **Installation**: Follow the installer instructions and ensure JAVA_HOME is set
+
+### 2. Node.js and npm
+- **Version**: Node.js 18 or later
+- **Download**: [Node.js Official Website](https://nodejs.org/)
+- **Installation**: The installer includes npm automatically
+
+### 3. Git (Optional but Recommended)
+- **Download**: [Git for Windows](https://git-scm.com/download/win)
+- **Installation**: Use default settings
+
+## Quick Start
+
+### Option 1: Using Batch Files (Recommended)
+
+1. **Clone or download the project**
+   ```cmd
+   git clone <repository-url>
+   cd MoneyPlant
+   ```
+
+2. **Run the main setup script**
+   ```cmd
+   start-application.bat
+   ```
+   This will:
+   - Check prerequisites
+   - Set up environment files
+   - Provide next steps
+
+3. **Start the backend**
+   ```cmd
+   start-backend.bat
+   ```
+
+4. **Start the frontend** (in a new command prompt)
+   ```cmd
+   cd frontend
+   npm start
+   ```
+
+### Option 2: Manual Setup
+
+1. **Set up backend environment**
+   ```cmd
+   cd backend
+   setup-env.bat
+   ```
+
+2. **Edit the .env file**
+   - Open `backend\.env` in a text editor
+   - Replace placeholder values with your actual credentials
+
+3. **Set up frontend environment**
+   ```cmd
+   cd frontend
+   setup-env.bat
+   ```
+
+4. **Install frontend dependencies**
+   ```cmd
+   cd frontend
+   npm install
+   ```
+
+5. **Start the backend**
+   ```cmd
+   cd backend
+   mvnw.cmd spring-boot:run -Dspring-boot.run.profiles=dev
+   ```
+
+6. **Start the frontend** (in a new command prompt)
+   ```cmd
+   cd frontend
+   npm start
+   ```
+
+## Troubleshooting
+
+### Issue: "mvn is not recognized as an internal or external command"
+
+**Solution**: The project now includes Maven wrapper files (`mvnw.cmd` and `mvnw`) that allow you to run Maven without installing it globally.
+
+- Use `mvnw.cmd` instead of `mvn` on Windows
+- The batch files have been updated to automatically detect and use the wrapper
+
+### Issue: "setup-env.bat is not found"
+
+**Solution**: The missing batch files have been created:
+- `backend\setup-env.bat` - Sets up backend environment
+- `frontend\setup-env.bat` - Sets up frontend environment
+
+### Issue: Java not found
+
+**Solution**: 
+1. Install Java 17 or later
+2. Set JAVA_HOME environment variable
+3. Add Java bin directory to PATH
+
+### Issue: Node.js not found
+
+**Solution**:
+1. Install Node.js 18 or later from [nodejs.org](https://nodejs.org/)
+2. Restart your command prompt after installation
+
+### Issue: Port already in use
+
+**Solution**:
+1. Check if another application is using port 8080 (backend) or 4200 (frontend)
+2. Kill the process using the port:
+   ```cmd
+   netstat -ano | findstr :8080
+   taskkill /PID <PID> /F
+   ```
+
+## Environment Configuration
+
+### Backend Environment (.env file)
+
+The backend requires several environment variables. The setup script creates a template file with the following sections:
+
+- **Database Configuration**: PostgreSQL connection settings
+- **OAuth2 Configuration**: Google and Microsoft authentication
+- **JWT Configuration**: Secret key for JWT tokens
+- **CORS Configuration**: Allowed origins for frontend
+- **Trino Configuration**: Apache Trino connection settings
+- **Application Configuration**: Spring Boot settings
+
+### Frontend Environment
+
+The frontend environment files are automatically generated based on the backend .env file:
+- `src/environments/environment.ts` (development)
+- `src/environments/environment.prod.ts` (production)
+
+## Security Notes
+
+- The `.env` file contains sensitive information and is in `.gitignore`
+- Never commit the `.env` file to version control
+- Use different credentials for development, staging, and production
+- Client IDs for OAuth are safe to include in frontend code
+- Client secrets should never be included in frontend code
+
+## Application URLs
+
+Once running, the application will be available at:
+
+- **Frontend**: http://localhost:4200
+- **Backend API**: http://localhost:8080
+- **API Documentation**: http://localhost:8080/swagger-ui.html
+- **Health Check**: http://localhost:8080/actuator/health
+
+## Development Tips
+
+1. **Use the Maven wrapper**: Always use `mvnw.cmd` instead of `mvn` to ensure consistent Maven version
+2. **Check logs**: Backend logs appear in the console where you ran `start-backend.bat`
+3. **Hot reload**: Frontend changes are automatically reloaded in the browser
+4. **Database**: Ensure your PostgreSQL database is running and accessible
+
+## Support
+
+If you encounter issues:
+
+1. Check the troubleshooting section above
+2. Verify all prerequisites are installed correctly
+3. Check the console output for error messages
+4. Ensure all environment variables are set correctly
+
+For additional help, refer to the main project documentation or create an issue in the repository. 

--- a/scripts/windows/backend/setup-env.bat
+++ b/scripts/windows/backend/setup-env.bat
@@ -1,0 +1,83 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo 🔐 MoneyPlant Frontend Environment Setup
+echo ==========================================
+echo.
+
+REM Check if we're in the frontend directory
+if not exist "angular.json" (
+    echo ❌ This script must be run from the frontend directory
+    pause
+    exit /b 1
+)
+
+REM Check if .env file exists in the backend directory
+if exist "..\backend\.env" (
+    echo 📋 Loading environment variables from backend .env file...
+    REM Load environment variables from backend .env file
+    for /f "tokens=1,* delims==" %%a in (..\backend\.env) do (
+        if not "%%a"=="" if not "%%a:~0,1%"=="#" (
+            set "%%a=%%b"
+        )
+    )
+) else (
+    echo ⚠️  Backend .env file not found. Using default values...
+    REM Set default values
+    set "GOOGLE_CLIENT_ID=your-google-client-id"
+    set "MICROSOFT_CLIENT_ID=your-microsoft-client-id"
+)
+
+echo 📝 Generating frontend environment files...
+echo.
+
+REM Generate development environment
+(
+echo export const environment = {
+echo   production: false,
+echo   apiUrl: 'http://localhost:8080',
+echo   useMockData: true,
+echo   
+echo   // OAuth Configuration
+echo   oauth: {
+echo     google: {
+echo       clientId: '!GOOGLE_CLIENT_ID!', // Replace with your Google Client ID
+echo       redirectUri: 'http://localhost:4200'
+echo     },
+echo     microsoft: {
+echo       clientId: '!MICROSOFT_CLIENT_ID!', // Replace with your Microsoft Azure AD Client ID
+echo       redirectUri: 'http://localhost:4200'
+echo     }
+echo   }
+echo };
+) > src\environments\environment.ts
+
+REM Generate production environment
+(
+echo export const environment = {
+echo   production: true,
+echo   apiUrl: '/api', // In production, the API is typically served from the same domain
+echo   useMockData: false,
+echo   
+echo   // OAuth Configuration
+echo   oauth: {
+echo     google: {
+echo       clientId: '!GOOGLE_CLIENT_ID!', // Replace with your Google Client ID
+echo       redirectUri: window.location.origin
+echo     },
+echo     microsoft: {
+echo       clientId: '!MICROSOFT_CLIENT_ID!', // Replace with your Microsoft Azure AD Client ID
+echo       redirectUri: window.location.origin
+echo     }
+echo   }
+echo };
+) > src\environments\environment.prod.ts
+
+echo ✅ Frontend environment files generated successfully!
+echo.
+echo 📋 Generated files:
+echo - src/environments/environment.ts (development)
+echo - src/environments/environment.prod.ts (production)
+echo.
+echo 🔒 Security reminder: Client IDs are not sensitive secrets and can be safely included in frontend code.
+echo However, client secrets should never be included in frontend code. 

--- a/scripts/windows/frontend/setup-env.bat
+++ b/scripts/windows/frontend/setup-env.bat
@@ -1,0 +1,83 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo 🔐 MoneyPlant Frontend Environment Setup
+echo ==========================================
+echo.
+
+REM Check if we're in the frontend directory
+if not exist "angular.json" (
+    echo ❌ This script must be run from the frontend directory
+    pause
+    exit /b 1
+)
+
+REM Check if .env file exists in the backend directory
+if exist "..\..\backend\.env" (
+    echo 📋 Loading environment variables from backend .env file...
+    REM Load environment variables from backend .env file
+    for /f "tokens=1,* delims==" %%a in (..\..\backend\.env) do (
+        if not "%%a"=="" if not "%%a:~0,1%"=="#" (
+            set "%%a=%%b"
+        )
+    )
+) else (
+    echo ⚠️  Backend .env file not found. Using default values...
+    REM Set default values
+    set "GOOGLE_CLIENT_ID=your-google-client-id"
+    set "MICROSOFT_CLIENT_ID=your-microsoft-client-id"
+)
+
+echo 📝 Generating frontend environment files...
+echo.
+
+REM Generate development environment
+(
+echo export const environment = {
+echo   production: false,
+echo   apiUrl: 'http://localhost:8080',
+echo   useMockData: true,
+echo   
+echo   // OAuth Configuration
+echo   oauth: {
+echo     google: {
+echo       clientId: '!GOOGLE_CLIENT_ID!', // Replace with your Google Client ID
+echo       redirectUri: 'http://localhost:4200'
+echo     },
+echo     microsoft: {
+echo       clientId: '!MICROSOFT_CLIENT_ID!', // Replace with your Microsoft Azure AD Client ID
+echo       redirectUri: 'http://localhost:4200'
+echo     }
+echo   }
+echo };
+) > src\environments\environment.ts
+
+REM Generate production environment
+(
+echo export const environment = {
+echo   production: true,
+echo   apiUrl: '/api', // In production, the API is typically served from the same domain
+echo   useMockData: false,
+echo   
+echo   // OAuth Configuration
+echo   oauth: {
+echo     google: {
+echo       clientId: '!GOOGLE_CLIENT_ID!', // Replace with your Google Client ID
+echo       redirectUri: window.location.origin
+echo     },
+echo     microsoft: {
+echo       clientId: '!MICROSOFT_CLIENT_ID!', // Replace with your Microsoft Azure AD Client ID
+echo       redirectUri: window.location.origin
+echo     }
+echo   }
+echo };
+) > src\environments\environment.prod.ts
+
+echo ✅ Frontend environment files generated successfully!
+echo.
+echo 📋 Generated files:
+echo - src/environments/environment.ts (development)
+echo - src/environments/environment.prod.ts (production)
+echo.
+echo 🔒 Security reminder: Client IDs are not sensitive secrets and can be safely included in frontend code.
+echo However, client secrets should never be included in frontend code. 

--- a/scripts/windows/start-backend.bat
+++ b/scripts/windows/start-backend.bat
@@ -1,0 +1,68 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo 🚀 Starting MoneyPlant Backend in Development Mode...
+echo Backend will be available at: http://localhost:8080
+echo API Documentation: http://localhost:8080/swagger-ui.html
+echo Health Check: http://localhost:8080/actuator/health
+echo.
+
+cd ..\..\backend
+
+REM Check if .env file exists
+if exist ".env" (
+    echo 📋 Loading environment variables from .env file...
+    REM Load environment variables from .env file
+    for /f "tokens=1,* delims==" %%a in (.env) do (
+        if not "%%a"=="" if not "%%a:~0,1%"=="#" (
+            set "%%a=%%b"
+        )
+    )
+) else (
+    echo ⚠️  .env file not found. Creating one with default values...
+    call ..\scripts\windows\backend\setup-env.bat
+    echo 📋 Loading environment variables from newly created .env file...
+    for /f "tokens=1,* delims==" %%a in (.env) do (
+        if not "%%a"=="" if not "%%a:~0,1%"=="#" (
+            set "%%a=%%b"
+        )
+    )
+)
+
+echo ✅ Environment variables loaded from .env file
+echo.
+
+REM Verify critical environment variables
+echo 🔍 Verifying environment variables:
+echo DB_HOST: %DB_HOST%
+echo DB_PASSWORD: [HIDDEN]
+echo MICROSOFT_CLIENT_ID: %MICROSOFT_CLIENT_ID%
+echo JWT_SECRET: [HIDDEN]
+echo.
+
+echo 🏃 Starting Spring Boot application...
+echo.
+
+REM Check if Maven is installed
+where mvn >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ❌ Maven is not installed or not in PATH.
+    echo.
+    echo 📋 To install Maven on Windows:
+    echo 1. Download Maven from: https://maven.apache.org/download.cgi
+    echo 2. Extract to a directory (e.g., C:\Program Files\Apache\maven)
+    echo 3. Add Maven bin directory to your PATH environment variable
+    echo 4. Restart your command prompt
+    echo.
+    echo 🔧 Alternative: Use the Maven wrapper (if available)
+    if exist "mvnw.cmd" (
+        echo ✅ Found Maven wrapper. Using mvnw.cmd instead...
+        mvnw.cmd spring-boot:run -Dspring-boot.run.profiles=dev
+    ) else (
+        echo ❌ Maven wrapper not found. Please install Maven.
+        pause
+        exit /b 1
+    )
+) else (
+    mvn spring-boot:run -Dspring-boot.run.profiles=dev
+) 

--- a/scripts/windows/start-frontend.bat
+++ b/scripts/windows/start-frontend.bat
@@ -1,0 +1,10 @@
+@echo off
+
+echo Starting MoneyPlant Frontend in Development Mode...
+echo Frontend will be available at: http://localhost:4200
+echo Make sure the backend is running on port 8080
+echo.
+
+cd frontend
+call npm install
+call npm run start:dev 

--- a/start-application.bat
+++ b/start-application.bat
@@ -5,8 +5,8 @@ echo.
 
 REM Check if we're on Windows
 if "%OS%"=="Windows_NT" (
-    echo ✅ Windows detected. Using Windows build scripts...
-    call build\start-application.bat
+    echo ✅ Windows detected. Using Windows scripts...
+    call scripts\start-application.bat
 ) else (
     echo ❌ This script is for Windows only.
     echo Please use start-application.sh for Linux/Mac.

--- a/start-application.sh
+++ b/start-application.sh
@@ -6,8 +6,8 @@ echo ""
 
 # Check if we're on Linux/Mac
 if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "✅ Linux/Mac detected. Using Linux build scripts..."
-    bash build/start-application.sh
+    echo "✅ Linux/Mac detected. Using Linux scripts..."
+    bash scripts/start-application.sh
 else
     echo "❌ This script is for Linux/Mac only."
     echo "Please use start-application.bat for Windows."

--- a/start-backend.bat
+++ b/start-backend.bat
@@ -5,8 +5,8 @@ echo.
 
 REM Check if we're on Windows
 if "%OS%"=="Windows_NT" (
-    echo ✅ Windows detected. Using Windows build scripts...
-    call build\windows\start-backend.bat
+    echo ✅ Windows detected. Using Windows scripts...
+    call scripts\windows\start-backend.bat
 ) else (
     echo ❌ This script is for Windows only.
     echo Please use start-backend.sh for Linux/Mac.

--- a/start-backend.sh
+++ b/start-backend.sh
@@ -6,8 +6,8 @@ echo ""
 
 # Check if we're on Linux/Mac
 if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "✅ Linux/Mac detected. Using Linux build scripts..."
-    bash build/linux/start-backend.sh
+    echo "✅ Linux/Mac detected. Using Linux scripts..."
+    bash scripts/linux/start-backend.sh
 else
     echo "❌ This script is for Linux/Mac only."
     echo "Please use start-backend.bat for Windows."

--- a/start-frontend.bat
+++ b/start-frontend.bat
@@ -5,8 +5,8 @@ echo.
 
 REM Check if we're on Windows
 if "%OS%"=="Windows_NT" (
-    echo ✅ Windows detected. Using Windows build scripts...
-    call build\windows\start-frontend.bat
+    echo ✅ Windows detected. Using Windows scripts...
+    call scripts\windows\start-frontend.bat
 ) else (
     echo ❌ This script is for Windows only.
     echo Please use start-frontend.sh for Linux/Mac.

--- a/start-frontend.sh
+++ b/start-frontend.sh
@@ -6,8 +6,8 @@ echo ""
 
 # Check if we're on Linux/Mac
 if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "✅ Linux/Mac detected. Using Linux build scripts..."
-    bash build/linux/start-frontend.sh
+    echo "✅ Linux/Mac detected. Using Linux scripts..."
+    bash scripts/linux/start-frontend.sh
 else
     echo "❌ This script is for Linux/Mac only."
     echo "Please use start-frontend.bat for Windows."


### PR DESCRIPTION
- Rename build/ to scripts/ to avoid .gitignore conflict
- Organize scripts by platform (windows/linux) and component (backend/frontend)
- Create root-level scripts with automatic platform detection
- Add comprehensive documentation for the new script structure
- Update all script references to use new directory structure
- Include Maven wrapper for consistent Maven version usage
- Add Windows setup guide and troubleshooting documentation